### PR TITLE
Plugin-based Celo fee currency PoC

### DIFF
--- a/src.ts/chain/celo.ts
+++ b/src.ts/chain/celo.ts
@@ -1,0 +1,177 @@
+import { getAddress } from "../address";
+import { Signature, keccak256 } from "../crypto";
+import { NetworkPlugin, PerformActionRequest, TransactionRequest } from "../providers";
+import { RpcInterceptorPlugin, TransactionPlugin } from "../providers/plugins-network";
+import { JsonRpcRequestBody } from "../providers/provider-jsonrpc";
+import { Transaction, TransactionLike } from "../transaction";
+import { parseEipSignature, formatAccessList, formatNumber, handleAccessList, handleAddress, handleNumber, handleUint } from "../transaction/transaction";
+import { assert, assertArgument, concat, decodeRlp, encodeRlp, getBytes, hexlify, toBeArray } from "../utils";
+
+export const CIP_64_TYPE_NUMBER = 123;
+export const CIP_64_TYPE_HEX = "0x7b";
+
+export type CeloCustomData = {
+    feeCurrency?: string;
+}
+
+export class Cip64Transaction extends Transaction {
+    #feeCurrency: string;
+
+    set feeCurrency(value: string) {
+        this.#feeCurrency = getAddress(value);
+    }
+
+    get feeCurrency(): string {
+        return this.#feeCurrency;
+    }
+
+    get type(): number { return CIP_64_TYPE_NUMBER; }
+
+    get typeName(): null | string {
+        return "cip-64";
+    }
+
+    get unsignedSerialized(): string {
+        return this.serialize();
+    }
+
+    get serialized(): string {
+        assert(this.signature != null, "cannot serialize unsigned transaction; maybe you meant .unsignedSerialized", "UNSUPPORTED_OPERATION", { operation: ".serialized"});
+
+        return this.serialize(this.signature);
+    }
+
+    private serialize(signature?: Signature) {
+        const fields: Array<any> = [
+            formatNumber(this.chainId || 0, "chainId"),
+            formatNumber(this.nonce || 0, "nonce"),
+            formatNumber(this.maxPriorityFeePerGas || 0, "maxPriorityFeePerGas"),
+            formatNumber(this.maxFeePerGas || 0, "maxFeePerGas"),
+            formatNumber(this.gasLimit || 0, "gasLimit"),
+            ((this.to != null) ? getAddress(this.to): "0x"),
+            formatNumber(this.value || 0, "value"),
+            (this.data || "0x"),
+            (formatAccessList(this.accessList || [])),
+            getAddress(this.feeCurrency!)
+        ];
+    
+        if (signature) {
+            fields.push(formatNumber(signature.yParity, "yParity"));
+            fields.push(toBeArray(signature.r));
+            fields.push(toBeArray(signature.s));
+        }
+    
+        return concat([ CIP_64_TYPE_HEX, encodeRlp(fields)]);
+    }
+}
+
+export class CeloRpcInterceptorPlugin extends RpcInterceptorPlugin {
+    public intercept(request: JsonRpcRequestBody, context: PerformActionRequest): JsonRpcRequestBody {
+        if (request.method === "eth_estimateGas" 
+            && context.method === "estimateGas"
+            && context.transaction.customData
+            && (context.transaction.customData as CeloCustomData).feeCurrency
+        ) {
+            request.args[0].feeCurrency = context.transaction.customData.feeCurrency;
+        }
+
+        return request;   
+    }
+
+    clone(): NetworkPlugin {
+        return new CeloRpcInterceptorPlugin();
+    }
+}
+
+export class CeloTransactionPlugin extends TransactionPlugin {
+    public determineType(tx: TransactionRequest): number | null | undefined {
+
+        if (tx.customData && (tx.customData as CeloCustomData).feeCurrency) {
+            return CIP_64_TYPE_NUMBER;
+        }
+
+        return tx.type;
+    }
+
+    public create(from?: string | TransactionLike<string>): Transaction {
+        if (!from) {
+            return new Transaction();
+        }
+
+        if (from instanceof Cip64Transaction) {
+            return from;
+        }
+
+        if (typeof from === "string") {
+            const payload = getBytes(from);
+
+            switch(payload[0]) {
+                case CIP_64_TYPE_NUMBER: return this.create(this.parseCip64(payload));
+            }
+
+            return Transaction.from(from);
+        }
+
+        if (from.type === CIP_64_TYPE_NUMBER && from.customData) {
+            const transaction = new Cip64Transaction();
+            
+            transaction.feeCurrency = from.customData.feeCurrency;            
+            
+            if (from.to != null) { transaction.to = from.to; }
+            if (from.nonce != null) { transaction.nonce = from.nonce; }
+            if (from.gasLimit != null) { transaction.gasLimit = from.gasLimit; }
+            if (from.gasPrice != null) { transaction.gasPrice = from.gasPrice; }
+            if (from.maxPriorityFeePerGas != null) { transaction.maxPriorityFeePerGas = from.maxPriorityFeePerGas; }
+            if (from.maxFeePerGas != null) { transaction.maxFeePerGas = from.maxFeePerGas; } 
+            if (from.data != null) { transaction.data = from.data; }
+            if (from.value != null) { transaction.value = from.value; }
+            if (from.chainId != null) { transaction.chainId = from.chainId; }
+            if (from.signature != null) { transaction.signature = Signature.from(from.signature); }
+            if (from.accessList != null) { transaction.accessList = from.accessList; }
+    
+            return transaction;
+        }
+
+        // Fallback to default
+        return Transaction.from(<TransactionLike<string>>from);
+    }
+
+    clone(): NetworkPlugin {
+        return new CeloTransactionPlugin();
+    }
+
+    private parseCip64(data: Uint8Array): TransactionLike {
+        const fields: any = decodeRlp(getBytes(data).slice(1));
+
+        assertArgument(Array.isArray(fields) && (fields.length === 10 || fields.length === 13),
+            "invalid field count for transaction type: CIP_64_TYPE_NUMBER", "data", hexlify(data));
+    
+        const maxPriorityFeePerGas = handleUint(fields[2], "maxPriorityFeePerGas");
+        const maxFeePerGas = handleUint(fields[3], "maxFeePerGas");
+        const tx: TransactionLike = {
+            type:                  CIP_64_TYPE_NUMBER,
+            chainId:               handleUint(fields[0], "chainId"),
+            nonce:                 handleNumber(fields[1], "nonce"),
+            maxPriorityFeePerGas:  maxPriorityFeePerGas,
+            maxFeePerGas:          maxFeePerGas,
+            gasPrice:              null,
+            gasLimit:              handleUint(fields[4], "gasLimit"),
+            to:                    handleAddress(fields[5]),
+            value:                 handleUint(fields[6], "value"),
+            data:                  hexlify(fields[7]),
+            accessList:            handleAccessList(fields[8], "accessList"),
+            customData: {
+                feeCurrency: handleAddress(fields[9])
+            } as CeloCustomData
+        };
+    
+        // Unsigned CIP-64 Transaction
+        if (fields.length === 10) { return tx; }
+    
+        tx.hash = keccak256(data);
+    
+        parseEipSignature(tx, fields.slice(10));
+    
+        return tx;
+    }
+}

--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -45,7 +45,7 @@ import type { BigNumberish, BytesLike } from "../utils/index.js";
 import type { Listener } from "../utils/index.js";
 
 import type { Networkish } from "./network.js";
-import type { FetchUrlFeeDataNetworkPlugin } from "./plugins-network.js";
+import { FetchUrlFeeDataNetworkPlugin, TransactionPlugin } from "./plugins-network.js";
 //import type { MaxPriorityFeePlugin } from "./plugins-network.js";
 import type {
     BlockParams, LogParams, TransactionReceiptParams,
@@ -1085,7 +1085,14 @@ export class AbstractProvider implements Provider {
              network: this.getNetwork()
         });
 
-        const tx = Transaction.from(signedTx);
+        let tx: Transaction;
+        const transactionPlugin = (await this.provider.getNetwork()).getPlugin<TransactionPlugin>(TransactionPlugin.NAME);
+        if (transactionPlugin) {
+            tx = transactionPlugin.create(signedTx);
+        } else {
+            tx = Transaction.from(signedTx);
+        }
+
         if (tx.hash !== hash) {
             throw new Error("@TODO: the returned hash did not match");
         }

--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -16,7 +16,7 @@ import type { BigNumberish } from "../utils/index.js";
 import type { TransactionLike } from "../transaction/index.js";
 
 import type { NetworkPlugin } from "./plugins-network.js";
-
+import { CeloRpcInterceptorPlugin, CeloTransactionPlugin } from "../chain/celo.js";
 
 /**
  *  A Networkish can be used to allude to a Network, by specifing:
@@ -430,4 +430,11 @@ function injectCommonNetworks(): void {
     registerEth("optimism-sepolia", 11155420, { });
 
     registerEth("xdai", 100, { ensNetwork: 1 });
+
+    registerEth("celo-alfajores", 44787, {
+        plugins: [
+            new CeloTransactionPlugin(),
+            new CeloRpcInterceptorPlugin()
+        ]
+    });
 }

--- a/src.ts/providers/plugins-network.ts
+++ b/src.ts/providers/plugins-network.ts
@@ -2,8 +2,11 @@ import { defineProperties } from "../utils/properties.js";
 
 import { assertArgument } from "../utils/index.js";
 
-import type { FeeData, Provider } from "./provider.js";
+import type { FeeData, Provider, TransactionRequest } from "./provider.js";
 import type { FetchRequest } from "../utils/fetch.js";
+import { Transaction, TransactionLike } from "../transaction/transaction.js";
+import { JsonRpcRequestBody } from "./provider-jsonrpc.js";
+import { PerformActionRequest } from "./abstract-provider.js";
 
 
 const EnsAddress = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
@@ -279,3 +282,25 @@ export class CustomBlockNetworkPlugin extends NetworkPlugin {
     }
 }
 */
+
+
+export abstract class TransactionPlugin extends NetworkPlugin {
+    public static NAME = "org.ethers.plugins.network.Transaction";
+
+    constructor() {
+        super(TransactionPlugin.NAME);
+    }
+
+    public abstract create(from?: string | TransactionLike<string>): Transaction;
+    public abstract determineType(tx: TransactionRequest): number | null | undefined;
+}
+
+export abstract class RpcInterceptorPlugin extends NetworkPlugin {
+    public static NAME = "org.ethers.plugins.network.RpcInterceptor";
+
+    constructor() {
+        super(RpcInterceptorPlugin.NAME);
+    }
+
+    public abstract intercept(request: JsonRpcRequestBody, context: PerformActionRequest): JsonRpcRequestBody;
+}

--- a/src.ts/transaction/transaction.ts
+++ b/src.ts/transaction/transaction.ts
@@ -109,14 +109,19 @@ export interface TransactionLike<A = string> {
      *  The versioned hashes (see [[link-eip-4844]]).
      */
     blobVersionedHashes?: null | Array<string>;
+
+    /**
+     * Custom chain specific data.
+     */
+    customData?: any;
 }
 
-function handleAddress(value: string): null | string {
+export function handleAddress(value: string): null | string {
     if (value === "0x") { return null; }
     return getAddress(value);
 }
 
-function handleAccessList(value: any, param: string): AccessList {
+export function handleAccessList(value: any, param: string): AccessList {
     try {
         return accessListify(value);
     } catch (error: any) {
@@ -124,26 +129,26 @@ function handleAccessList(value: any, param: string): AccessList {
     }
 }
 
-function handleNumber(_value: string, param: string): number {
+export function handleNumber(_value: string, param: string): number {
     if (_value === "0x") { return 0; }
     return getNumber(_value, param);
 }
 
-function handleUint(_value: string, param: string): bigint {
+export function handleUint(_value: string, param: string): bigint {
     if (_value === "0x") { return BN_0; }
     const value = getBigInt(_value, param);
     assertArgument(value <= BN_MAX_UINT, "value exceeds uint size", param, value);
     return value;
 }
 
-function formatNumber(_value: BigNumberish, name: string): Uint8Array {
+export function formatNumber(_value: BigNumberish, name: string): Uint8Array {
     const value = getBigInt(_value, "value");
     const result = toBeArray(value);
     assertArgument(result.length <= 32, `value too large`, `tx.${ name }`, value);
     return result;
 }
 
-function formatAccessList(value: AccessListish): Array<[ string, Array<string> ]> {
+export function formatAccessList(value: AccessListish): Array<[ string, Array<string> ]> {
     return accessListify(value).map((set) => [ set.address, set.storageKeys ]);
 }
 
@@ -263,7 +268,7 @@ function _serializeLegacy(tx: Transaction, sig?: Signature): string {
     return encodeRlp(fields);
 }
 
-function _parseEipSignature(tx: TransactionLike, fields: Array<string>): void {
+export function parseEipSignature(tx: TransactionLike, fields: Array<string>): void {
     let yParity: number;
     try {
         yParity = handleNumber(fields[0], "yParity");
@@ -304,7 +309,7 @@ function _parseEip1559(data: Uint8Array): TransactionLike {
 
     tx.hash = keccak256(data);
 
-    _parseEipSignature(tx, fields.slice(9));
+    parseEipSignature(tx, fields.slice(9));
 
     return tx;
 }
@@ -354,7 +359,7 @@ function _parseEip2930(data: Uint8Array): TransactionLike {
 
     tx.hash = keccak256(data);
 
-    _parseEipSignature(tx, fields.slice(8));
+    parseEipSignature(tx, fields.slice(8));
 
     return tx;
 }
@@ -414,7 +419,7 @@ function _parseEip4844(data: Uint8Array): TransactionLike {
 
     tx.hash = keccak256(data);
 
-    _parseEipSignature(tx, fields.slice(11));
+    parseEipSignature(tx, fields.slice(11));
 
     return tx;
 }


### PR DESCRIPTION
Aim of this PR is to show how support for fee currencies could be achieved using existing plugin architecture.

To test it I used the following script that existed in a directory adjacent to directory to which ethers has been cloned to. I ran it using [bun](https://bun.sh/).

It requires `dotenv` to work and `PRIVATE_KEY` specified in `.env` file although can be modified to work without it.

It works with alfajores network only for now.

It also requires the sender to have sufficient funds to a) transfer CELO b) pay for the fee currency. Both can be acquired using [the faucet](https://faucet.celo.org/alfajores).

```typescript
import "dotenv/config";
import { JsonRpcProvider, Wallet } from "../ethers.js/src.ts";
import { CeloCustomData } from "../ethers.js/src.ts/chain/celo.ts";

const provider = new JsonRpcProvider("https://alfajores-forno.celo-testnet.org");
const signer = new Wallet(process.env.PRIVATE_KEY as string, provider);

let tx;

// Try to send a CELO CIP-64 transaction
tx = await signer.sendTransaction({
    to: signer.address,
    value: 1n,
    customData: {
        feeCurrency: "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1"
    } as CeloCustomData
});
  
// should be true
console.log(tx.type === 123);

// Try to send an EIP-1559 transaction
tx = await signer.sendTransaction({
    to: signer.address,
    value: 1n,
});
  
// should be true
console.log(tx.type === 2);
```

When everything works correctly the script should output:

```
$ bun goal.ts

true
true
```