### PR TITLE
Type-based Celo fee currency PoC

### DIFF
--- a/src.ts/chain/celo.ts
+++ b/src.ts/chain/celo.ts
@@ -22,7 +22,7 @@ interface CeloPreparedTransactionRequest extends PreparedTransactionRequest {
 }
 
 export class Cip64Transaction extends Transaction {
-    #feeCurrency: string;
+    #feeCurrency: string = "";
 
     set feeCurrency(value: string) {
         this.#feeCurrency = getAddress(value);
@@ -122,7 +122,7 @@ export const celoAlfajores = {
 
         return result;
     },
-    createTransaction: (from: TransactionLike | string) => {
+    createTransaction: (from: TransactionLike | string): Transaction => {
         if (!from) {
             return new Transaction();
         }

--- a/src.ts/chain/celo.ts
+++ b/src.ts/chain/celo.ts
@@ -1,0 +1,168 @@
+import { AddressLike, getAddress } from "../address";
+import { Signature, keccak256 } from "../crypto";
+import { PreparedTransactionRequest, TransactionRequest } from "../providers";
+import { Transaction, TransactionLike } from "../transaction";
+import { formatAccessList, formatNumber, handleAccessList, handleAddress, handleNumber, handleUint, parseEipSignature } from "../transaction/transaction";
+import { assert, assertArgument, concat, decodeRlp, encodeRlp, getBytes, hexlify, toBeArray } from "../utils";
+
+export const CIP_64_TYPE_NUMBER = 123;
+export const CIP_64_TYPE_HEX = "0x7b";
+
+interface CeloTransactionLike extends TransactionLike {
+    feeCurrency?: string;
+}
+
+interface CeloTransactionRequest extends TransactionRequest {
+    feeCurrency?: string;
+}
+
+interface CeloPreparedTransactionRequest extends PreparedTransactionRequest {
+    feeCurrency?: AddressLike;
+}
+
+export class Cip64Transaction extends Transaction {
+    #feeCurrency: string;
+
+    set feeCurrency(value: string) {
+        // TODO check if that's sufficient
+        this.#feeCurrency = getAddress(value);
+    }
+
+    get feeCurrency(): string {
+        return this.#feeCurrency;
+    }
+
+    get type(): number { return CIP_64_TYPE_NUMBER; }
+
+    get typeName(): null | string {
+        return "cip-64";
+    }
+
+    get unsignedSerialized(): string {
+        return this.serialize();
+    }
+
+    get serialized(): string {
+        assert(this.signature != null, "cannot serialize unsigned transaction; maybe you meant .unsignedSerialized", "UNSUPPORTED_OPERATION", { operation: ".serialized" });
+
+        return this.serialize(this.signature);
+    }
+
+    private serialize(signature?: Signature) {
+        const fields: Array<any> = [
+            formatNumber(this.chainId || 0, "chainId"),
+            formatNumber(this.nonce || 0, "nonce"),
+            formatNumber(this.maxPriorityFeePerGas || 0, "maxPriorityFeePerGas"),
+            formatNumber(this.maxFeePerGas || 0, "maxFeePerGas"),
+            formatNumber(this.gasLimit || 0, "gasLimit"),
+            ((this.to != null) ? getAddress(this.to) : "0x"),
+            formatNumber(this.value || 0, "value"),
+            (this.data || "0x"),
+            (formatAccessList(this.accessList || [])),
+            getAddress(this.feeCurrency!)
+        ];
+
+        if (signature) {
+            fields.push(formatNumber(signature.yParity, "yParity"));
+            fields.push(toBeArray(signature.r));
+            fields.push(toBeArray(signature.s));
+        }
+
+        return concat([CIP_64_TYPE_HEX, encodeRlp(fields)]);
+    }
+
+    public static parseCip64(data: Uint8Array): CeloTransactionLike {
+        const fields: any = decodeRlp(getBytes(data).slice(1));
+
+        assertArgument(Array.isArray(fields) && (fields.length === 10 || fields.length === 13),
+            "invalid field count for transaction type: CIP_64_TYPE_NUMBER", "data", hexlify(data));
+
+        const maxPriorityFeePerGas = handleUint(fields[2], "maxPriorityFeePerGas");
+        const maxFeePerGas = handleUint(fields[3], "maxFeePerGas");
+        const tx: CeloTransactionLike = {
+            type: CIP_64_TYPE_NUMBER,
+            chainId: handleUint(fields[0], "chainId"),
+            nonce: handleNumber(fields[1], "nonce"),
+            maxPriorityFeePerGas: maxPriorityFeePerGas,
+            maxFeePerGas: maxFeePerGas,
+            gasPrice: null,
+            gasLimit: handleUint(fields[4], "gasLimit"),
+            to: handleAddress(fields[5]),
+            value: handleUint(fields[6], "value"),
+            data: hexlify(fields[7]),
+            accessList: handleAccessList(fields[8], "accessList"),
+            feeCurrency: handleAddress(fields[9]) || undefined
+        };
+
+        // Unsigned CIP-64 Transaction
+        if (fields.length === 10) { return tx; }
+
+        tx.hash = keccak256(data);
+
+        parseEipSignature(tx, fields.slice(10));
+
+        return tx;
+    }
+}
+
+export const celoAlfajores = {
+    populateTransaction: (tx: CeloTransactionRequest) => {
+        if (tx.feeCurrency) {
+            tx.type = CIP_64_TYPE_NUMBER;
+        }
+
+        return tx as CeloTransactionLike;
+    },
+    prepareTransactionRequest: (request: CeloTransactionRequest) => {
+        const result: CeloPreparedTransactionRequest = {};
+        
+        if (request.feeCurrency) {
+            // TODO check if that's sufficient
+            result.feeCurrency = getAddress(request.feeCurrency);
+        }
+
+        return result;
+    },
+    createTransaction: (from: TransactionLike) => {
+        if (!from) {
+            return new Transaction();
+        }
+
+        if (from instanceof Cip64Transaction) {
+            return from;
+        }
+
+        if (typeof from === "string") {
+            const payload = getBytes(from);
+
+            switch (payload[0]) {
+                case CIP_64_TYPE_NUMBER: return celoAlfajores.createTransaction(Cip64Transaction.parseCip64(payload));
+            }
+
+            return Transaction.from(from);
+        }
+
+        if (from.type === CIP_64_TYPE_NUMBER && (from as CeloTransactionLike).feeCurrency) {
+            const transaction = new Cip64Transaction();
+
+            transaction.feeCurrency = (from as CeloTransactionLike).feeCurrency as string;
+
+            if (from.to != null) { transaction.to = from.to; }
+            if (from.nonce != null) { transaction.nonce = from.nonce; }
+            if (from.gasLimit != null) { transaction.gasLimit = from.gasLimit; }
+            if (from.gasPrice != null) { transaction.gasPrice = from.gasPrice; }
+            if (from.maxPriorityFeePerGas != null) { transaction.maxPriorityFeePerGas = from.maxPriorityFeePerGas; }
+            if (from.maxFeePerGas != null) { transaction.maxFeePerGas = from.maxFeePerGas; }
+            if (from.data != null) { transaction.data = from.data; }
+            if (from.value != null) { transaction.value = from.value; }
+            if (from.chainId != null) { transaction.chainId = from.chainId; }
+            if (from.signature != null) { transaction.signature = Signature.from(from.signature); }
+            if (from.accessList != null) { transaction.accessList = from.accessList; }
+
+            return transaction;
+        }
+
+        // Fallback to default
+        return Transaction.from(<TransactionLike<string>>from);
+    }
+}

--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -1085,6 +1085,7 @@ export class AbstractProvider implements Provider {
              network: this.getNetwork()
         });
 
+        // TODO: add network overrides here
         const tx = Transaction.from(signedTx);
         if (tx.hash !== hash) {
             throw new Error("@TODO: the returned hash did not match");

--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -44,7 +44,7 @@ import type { Addressable, AddressLike } from "../address/index.js";
 import type { BigNumberish, BytesLike } from "../utils/index.js";
 import type { Listener } from "../utils/index.js";
 
-import type { Networkish } from "./network.js";
+import type { Networkish, NetworkOverrides } from "./network.js";
 import type { FetchUrlFeeDataNetworkPlugin } from "./plugins-network.js";
 //import type { MaxPriorityFeePlugin } from "./plugins-network.js";
 import type {
@@ -443,7 +443,7 @@ type CcipArgs = {
  *  formatting output results as well as tracking events for consistent
  *  behaviour on an eventually-consistent network.
  */
-export class AbstractProvider implements Provider {
+export class AbstractProvider<TNetworkOverrides extends NetworkOverrides = {}> implements Provider {
 
     #subs: Map<string, Sub>;
     #plugins: Map<string, AbstractProviderPlugin>;
@@ -468,12 +468,14 @@ export class AbstractProvider implements Provider {
 
     #options: Required<AbstractProviderOptions>;
 
+    protected networkOverrides?: TNetworkOverrides;
+
     /**
      *  Create a new **AbstractProvider** connected to %%network%%, or
      *  use the various network detection capabilities to discover the
      *  [[Network]] if necessary.
      */
-    constructor(_network?: "any" | Networkish, options?: AbstractProviderOptions) {
+    constructor(_network?: "any" | Networkish, options?: AbstractProviderOptions, networkOverrides?: TNetworkOverrides) {
         this.#options = Object.assign({ }, defaultOptions, options || { });
 
         if (_network === "any") {
@@ -503,6 +505,7 @@ export class AbstractProvider implements Provider {
         this.#timers = new Map();
 
         this.#disableCcipRead = false;
+        this.networkOverrides = networkOverrides;
     }
 
     get pollingInterval(): number { return this.#options.pollingInterval; }
@@ -823,7 +826,7 @@ export class AbstractProvider implements Provider {
      *  transaction.
      */
     _getTransactionRequest(_request: TransactionRequest): PerformActionTransaction | Promise<PerformActionTransaction> {
-        const request = <PerformActionTransaction>copyRequest(_request);
+        const request = <PerformActionTransaction>copyRequest(_request, this.networkOverrides);
 
         const promises: Array<Promise<void>> = [ ];
         [ "to", "from" ].forEach((key) => {
@@ -1085,8 +1088,9 @@ export class AbstractProvider implements Provider {
              network: this.getNetwork()
         });
 
-        // TODO: add network overrides here
-        const tx = Transaction.from(signedTx);
+        const tx = this.networkOverrides && this.networkOverrides.createTransaction
+            ? this.networkOverrides.createTransaction(signedTx)
+            : Transaction.from(signedTx)
         if (tx.hash !== hash) {
             throw new Error("@TODO: the returned hash did not match");
         }

--- a/src.ts/providers/abstract-signer.ts
+++ b/src.ts/providers/abstract-signer.ts
@@ -22,14 +22,15 @@ import type {
 } from "./provider.js";
 import type { Signer } from "./signer.js";
 
+import { NetworkDefaults, NetworkOverrides } from "./network.js";
 
 function checkProvider(signer: AbstractSigner, operation: string): Provider {
     if (signer.provider) { return signer.provider; }
     assert(false, "missing provider", "UNSUPPORTED_OPERATION", { operation });
 }
 
-async function populate(signer: AbstractSigner, tx: TransactionRequest): Promise<TransactionLike<string>> {
-    let pop: any = copyRequest(tx);
+async function populate(signer: AbstractSigner, tx: TransactionRequest, networkOverrides?: NetworkOverrides): Promise<TransactionLike<string>> {
+    let pop: any = copyRequest(tx, networkOverrides);
 
     if (pop.to != null) { pop.to = resolveAddress(pop.to, signer); }
 
@@ -47,6 +48,13 @@ async function populate(signer: AbstractSigner, tx: TransactionRequest): Promise
         pop.from = signer.getAddress();
     }
 
+    if (networkOverrides && networkOverrides.populateTransaction) {
+        return await resolveProperties({
+            ...pop,
+            ...networkOverrides.populateTransaction(tx)
+        });
+    }
+
     return await resolveProperties(pop);
 }
 
@@ -57,17 +65,33 @@ async function populate(signer: AbstractSigner, tx: TransactionRequest): Promise
  *  Signer-specific methods be overridden.
  *
  */
-export abstract class AbstractSigner<P extends null | Provider = null | Provider> implements Signer {
+export abstract class AbstractSigner<P extends null | Provider = null | Provider, TNetworkOverrides extends NetworkOverrides = {}> implements Signer<TNetworkOverrides> {
     /**
      *  The provider this signer is connected to.
      */
     readonly provider!: P;
 
+    readonly networkOverrides?: TNetworkOverrides;
+
     /**
      *  Creates a new Signer connected to %%provider%%.
      */
-    constructor(provider?: P) {
-        defineProperties<AbstractSigner>(this, { provider: (provider || null) });
+    constructor(provider?: P, networkOverrides?: TNetworkOverrides) {
+        defineProperties<AbstractSigner>(
+            this, 
+            { 
+                provider: (provider || null)
+            }
+        );
+
+        if (networkOverrides) {
+            defineProperties<AbstractSigner>(
+                this, 
+                { 
+                    networkOverrides
+                }
+            );
+        }
     }
 
     /**
@@ -88,14 +112,14 @@ export abstract class AbstractSigner<P extends null | Provider = null | Provider
     }
 
     async populateCall(tx: TransactionRequest): Promise<TransactionLike<string>> {
-        const pop = await populate(this, tx);
+        const pop = await populate(this, tx, this.networkOverrides);
         return pop;
     }
 
     async populateTransaction(tx: TransactionRequest): Promise<TransactionLike<string>> {
         const provider = checkProvider(this, "populateTransaction");
 
-        const pop = await populate(this, tx);
+        const pop = await populate(this, tx, this.networkOverrides);
 
         if (pop.nonce == null) {
             pop.nonce = await this.getNonce("pending");
@@ -208,6 +232,10 @@ export abstract class AbstractSigner<P extends null | Provider = null | Provider
             }
         }
 
+        if (this.networkOverrides && this.networkOverrides.populateTransaction) {
+            return await resolveProperties(this.networkOverrides.populateTransaction(pop));
+        }
+
 //@TOOD: Don't await all over the place; save them up for
 // the end for better batching
         return await resolveProperties(pop);
@@ -226,12 +254,22 @@ export abstract class AbstractSigner<P extends null | Provider = null | Provider
         return await provider.resolveName(name);
     }
 
-    async sendTransaction(tx: TransactionRequest): Promise<TransactionResponse> {
+    async sendTransaction(
+        tx: TNetworkOverrides["populateTransaction"] extends (tx: TransactionRequest) => TransactionLike
+            ? Parameters<TNetworkOverrides["populateTransaction"]>[0]
+            : Parameters<NetworkDefaults["populateTransaction"]>[0]
+    ): Promise<TransactionResponse> {
+
         const provider = checkProvider(this, "sendTransaction");
 
         const pop = await this.populateTransaction(tx);
+
         delete pop.from;
-        const txObj = Transaction.from(pop);
+
+        const txObj = this.networkOverrides && this.networkOverrides.createTransaction
+            ? this.networkOverrides.createTransaction(pop)
+            : Transaction.from(pop);
+        
         return await provider.broadcastTransaction(await this.signTransaction(txObj));
     }
 

--- a/src.ts/providers/abstract-signer.ts
+++ b/src.ts/providers/abstract-signer.ts
@@ -48,13 +48,6 @@ async function populate(signer: AbstractSigner, tx: TransactionRequest, networkO
         pop.from = signer.getAddress();
     }
 
-    if (networkOverrides && networkOverrides.populateTransaction) {
-        return await resolveProperties({
-            ...pop,
-            ...networkOverrides.populateTransaction(tx)
-        });
-    }
-
     return await resolveProperties(pop);
 }
 

--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -13,10 +13,11 @@ import {
 } from "./plugins-network.js";
 
 import type { BigNumberish } from "../utils/index.js";
-import type { TransactionLike } from "../transaction/index.js";
+import type { Transaction, TransactionLike } from "../transaction/index.js";
 
 import type { NetworkPlugin } from "./plugins-network.js";
 
+import { PreparedTransactionRequest, TransactionRequest } from "./provider.js";
 
 /**
  *  A Networkish can be used to allude to a Network, by specifing:
@@ -57,6 +58,15 @@ export class LayerOneConnectionPlugin extends NetworkPlugin {
 
 const Networks: Map<string | bigint, () => Network> = new Map();
 
+export type NetworkOverrides = {
+    prepareTransactionRequest?: (tx: TransactionRequest) => PreparedTransactionRequest;
+    populateTransaction?: (tx: TransactionRequest) => TransactionLike;
+    createTransaction?: (from: TransactionLike) => Transaction;
+}
+
+export type NetworkDefaults = {
+    populateTransaction: (tx: TransactionRequest) => TransactionLike;    
+}
 
 /**
  *  A **Network** provides access to a chain's properties and allows

--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -18,6 +18,8 @@ import type { Transaction, TransactionLike } from "../transaction/index.js";
 import type { NetworkPlugin } from "./plugins-network.js";
 
 import { PreparedTransactionRequest, TransactionRequest } from "./provider.js";
+import { JsonRpcRequestBody } from "./provider-jsonrpc.js";
+import { PerformActionRequest } from "./abstract-provider.js";
 
 /**
  *  A Networkish can be used to allude to a Network, by specifing:
@@ -61,7 +63,8 @@ const Networks: Map<string | bigint, () => Network> = new Map();
 export type NetworkOverrides = {
     prepareTransactionRequest?: (tx: TransactionRequest) => PreparedTransactionRequest;
     populateTransaction?: (tx: TransactionRequest) => TransactionLike;
-    createTransaction?: (from: TransactionLike) => Transaction;
+    createTransaction?: (from: TransactionLike | string) => Transaction;
+    getRpcRequest?: (request: JsonRpcRequestBody | null, context: PerformActionRequest) => JsonRpcRequestBody | null;
 }
 
 export type NetworkDefaults = {

--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -1299,3 +1299,7 @@ function spelunkMessage(value: any): Array<string> {
     _spelunkMessage(value, result);
     return result;
 }
+
+export const createJsonRpcProvider = <networkOverrides extends NetworkOverrides>(url?: string | FetchRequest, network?: Networkish, options?: JsonRpcApiProviderOptions, networkOverrides?: networkOverrides) => {
+    return new JsonRpcProvider<networkOverrides>(url, network, options, networkOverrides);
+}

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -11,7 +11,7 @@ import type { Signature } from "../crypto/index.js";
 import type { AccessList, AccessListish, TransactionLike } from "../transaction/index.js";
 
 import type { ContractRunner } from "./contracts.js";
-import type { Network } from "./network.js";
+import type { Network, NetworkOverrides } from "./network.js";
 
 
 const BN_0 = BigInt(0);
@@ -323,7 +323,7 @@ export interface PreparedTransactionRequest {
  *  Returns a copy of %%req%% with all properties coerced to their strict
  *  types.
  */
-export function copyRequest(req: TransactionRequest): PreparedTransactionRequest {
+export function copyRequest(req: TransactionRequest, networkOverrides?: NetworkOverrides): PreparedTransactionRequest {
     const result: any = { };
 
     // These could be addresses, ENS names or Addressables
@@ -356,6 +356,13 @@ export function copyRequest(req: TransactionRequest): PreparedTransactionRequest
 
     if ("customData" in req) {
         result.customData = req.customData;
+    }
+
+    if (networkOverrides && networkOverrides.prepareTransactionRequest) {
+        return {
+            ...result,
+            ...networkOverrides.prepareTransactionRequest(req)
+        };
     }
 
     return result;

--- a/src.ts/providers/signer.ts
+++ b/src.ts/providers/signer.ts
@@ -4,6 +4,7 @@ import type { TypedDataDomain, TypedDataField } from "../hash/index.js";
 import type { TransactionLike } from "../transaction/index.js";
 
 import type { ContractRunner } from "./contracts.js";
+import { NetworkDefaults, NetworkOverrides } from "./network.js";
 import type { BlockTag, Provider, TransactionRequest, TransactionResponse } from "./provider.js";
 
 /**
@@ -14,7 +15,7 @@ import type { BlockTag, Provider, TransactionRequest, TransactionResponse } from
  *  Signing entities, such as Smart Contract Wallets or Virtual Wallets (where the
  *  private key may not be known).
  */
-export interface Signer extends Addressable, ContractRunner, NameResolver {
+export interface Signer<TNetworkOverrides extends NetworkOverrides = NetworkDefaults> extends Addressable, ContractRunner, NameResolver {
 
     /**
      *  The [[Provider]] attached to this Signer (if any).
@@ -128,7 +129,11 @@ export interface Signer extends Addressable, ContractRunner, NameResolver {
      *  is called first to ensure all necessary properties for the
      *  transaction to be valid have been popualted first.
      */
-    sendTransaction(tx: TransactionRequest): Promise<TransactionResponse>;
+    sendTransaction(
+        tx: TNetworkOverrides["populateTransaction"] extends (tx: TransactionRequest) => TransactionLike
+            ? Parameters<TNetworkOverrides["populateTransaction"]>[0]
+            : Parameters<NetworkDefaults["populateTransaction"]>[0] 
+    ): Promise<TransactionResponse>;
 
     /**
      *  Signs an [[link-eip-191]] prefixed personal message.

--- a/src.ts/transaction/transaction.ts
+++ b/src.ts/transaction/transaction.ts
@@ -111,12 +111,12 @@ export interface TransactionLike<A = string> {
     blobVersionedHashes?: null | Array<string>;
 }
 
-function handleAddress(value: string): null | string {
+export function handleAddress(value: string): null | string {
     if (value === "0x") { return null; }
     return getAddress(value);
 }
 
-function handleAccessList(value: any, param: string): AccessList {
+export function handleAccessList(value: any, param: string): AccessList {
     try {
         return accessListify(value);
     } catch (error: any) {
@@ -124,26 +124,26 @@ function handleAccessList(value: any, param: string): AccessList {
     }
 }
 
-function handleNumber(_value: string, param: string): number {
+export function handleNumber(_value: string, param: string): number {
     if (_value === "0x") { return 0; }
     return getNumber(_value, param);
 }
 
-function handleUint(_value: string, param: string): bigint {
+export function handleUint(_value: string, param: string): bigint {
     if (_value === "0x") { return BN_0; }
     const value = getBigInt(_value, param);
     assertArgument(value <= BN_MAX_UINT, "value exceeds uint size", param, value);
     return value;
 }
 
-function formatNumber(_value: BigNumberish, name: string): Uint8Array {
+export function formatNumber(_value: BigNumberish, name: string): Uint8Array {
     const value = getBigInt(_value, "value");
     const result = toBeArray(value);
     assertArgument(result.length <= 32, `value too large`, `tx.${ name }`, value);
     return result;
 }
 
-function formatAccessList(value: AccessListish): Array<[ string, Array<string> ]> {
+export function formatAccessList(value: AccessListish): Array<[ string, Array<string> ]> {
     return accessListify(value).map((set) => [ set.address, set.storageKeys ]);
 }
 
@@ -263,7 +263,7 @@ function _serializeLegacy(tx: Transaction, sig?: Signature): string {
     return encodeRlp(fields);
 }
 
-function _parseEipSignature(tx: TransactionLike, fields: Array<string>): void {
+export function parseEipSignature(tx: TransactionLike, fields: Array<string>): void {
     let yParity: number;
     try {
         yParity = handleNumber(fields[0], "yParity");
@@ -304,7 +304,7 @@ function _parseEip1559(data: Uint8Array): TransactionLike {
 
     tx.hash = keccak256(data);
 
-    _parseEipSignature(tx, fields.slice(9));
+    parseEipSignature(tx, fields.slice(9));
 
     return tx;
 }
@@ -354,7 +354,7 @@ function _parseEip2930(data: Uint8Array): TransactionLike {
 
     tx.hash = keccak256(data);
 
-    _parseEipSignature(tx, fields.slice(8));
+    parseEipSignature(tx, fields.slice(8));
 
     return tx;
 }
@@ -414,7 +414,7 @@ function _parseEip4844(data: Uint8Array): TransactionLike {
 
     tx.hash = keccak256(data);
 
-    _parseEipSignature(tx, fields.slice(11));
+    parseEipSignature(tx, fields.slice(11));
 
     return tx;
 }

--- a/src.ts/wallet/base-wallet.ts
+++ b/src.ts/wallet/base-wallet.ts
@@ -10,6 +10,7 @@ import type { SigningKey } from "../crypto/index.js";
 import type { TypedDataDomain, TypedDataField } from "../hash/index.js";
 import type { Provider, TransactionRequest } from "../providers/index.js";
 import type { TransactionLike } from "../transaction/index.js";
+import { NetworkOverrides } from "../providers/network.js";
 
 
 /**
@@ -23,7 +24,7 @@ import type { TransactionLike } from "../transaction/index.js";
  *  This class may be of use for those attempting to implement
  *  a minimal Signer.
  */
-export class BaseWallet extends AbstractSigner {
+export class BaseWallet<TNetworkOverrides extends NetworkOverrides = {}> extends AbstractSigner<null, TNetworkOverrides> {
     /**
      *  The wallet address.
      */
@@ -38,8 +39,9 @@ export class BaseWallet extends AbstractSigner {
      *  If %%provider%% is not specified, only offline methods can
      *  be used.
      */
-    constructor(privateKey: SigningKey, provider?: null | Provider) {
-        super(provider);
+    constructor(privateKey: SigningKey, provider?: null | Provider, networkOverrides?: TNetworkOverrides) {
+        // TODO fix provider typing error
+        super(provider, networkOverrides);
 
         assertArgument(privateKey && typeof(privateKey.sign) === "function", "invalid private key", "privateKey", "[ REDACTED ]");
 
@@ -86,7 +88,10 @@ export class BaseWallet extends AbstractSigner {
         }
 
         // Build the transaction
-        const btx = Transaction.from(<TransactionLike<string>>tx);
+        const btx = this.networkOverrides && this.networkOverrides.createTransaction
+            ? this.networkOverrides.createTransaction(<TransactionLike<string>>tx)
+            : Transaction.from(<TransactionLike<string>>tx);
+
         btx.signature = this.signingKey.sign(btx.unsignedHash);
 
         return btx.serialized;

--- a/src.ts/wallet/base-wallet.ts
+++ b/src.ts/wallet/base-wallet.ts
@@ -24,7 +24,7 @@ import { NetworkOverrides } from "../providers/network.js";
  *  This class may be of use for those attempting to implement
  *  a minimal Signer.
  */
-export class BaseWallet<TNetworkOverrides extends NetworkOverrides = {}> extends AbstractSigner<null, TNetworkOverrides> {
+export class BaseWallet<TNetworkOverrides extends NetworkOverrides = {}> extends AbstractSigner<Provider | null, TNetworkOverrides> {
     /**
      *  The wallet address.
      */
@@ -40,7 +40,6 @@ export class BaseWallet<TNetworkOverrides extends NetworkOverrides = {}> extends
      *  be used.
      */
     constructor(privateKey: SigningKey, provider?: null | Provider, networkOverrides?: TNetworkOverrides) {
-        // TODO fix provider typing error
         super(provider, networkOverrides);
 
         assertArgument(privateKey && typeof(privateKey.sign) === "function", "invalid private key", "privateKey", "[ REDACTED ]");

--- a/src.ts/wallet/wallet.ts
+++ b/src.ts/wallet/wallet.ts
@@ -12,10 +12,11 @@ import {
 import { Mnemonic } from "./mnemonic.js";
 
 import type { ProgressCallback } from "../crypto/index.js";
-import type { Provider } from "../providers/index.js";
+import type { Provider, TransactionRequest } from "../providers/index.js";
 
 import type { CrowdsaleAccount } from "./json-crowdsale.js";
 import type { KeystoreAccount } from "./json-keystore.js";
+import { NetworkOverrides } from "../providers/network.js";
 
 
 function stall(duration: number): Promise<void> {
@@ -32,19 +33,19 @@ function stall(duration: number): Promise<void> {
  *  raw private key, [[link-bip-39]] mnemonics and encrypte JSON
  *  wallets.
  */
-export class Wallet extends BaseWallet {
+export class Wallet<TNetworkOverrides extends NetworkOverrides = {}> extends BaseWallet<TNetworkOverrides> {
 
     /**
      *  Create a new wallet for the private %%key%%, optionally connected
      *  to %%provider%%.
      */
-    constructor(key: string | SigningKey, provider?: null | Provider) {
+    constructor(key: string | SigningKey, provider?: null | Provider, networkOverrides?: TNetworkOverrides) {
         if (typeof(key) === "string" && !key.startsWith("0x")) {
             key = "0x" + key;
         }
 
         let signingKey = (typeof(key) === "string") ? new SigningKey(key): key;
-        super(signingKey, provider);
+        super(signingKey, provider, networkOverrides);
     }
 
     connect(provider: null | Provider): Wallet {
@@ -160,4 +161,9 @@ export class Wallet extends BaseWallet {
         if (provider) { return wallet.connect(provider); }
         return wallet;
     }
+}
+
+// TODO networkOverrides should be optional
+export const createWallet = <networkOverrides extends NetworkOverrides>(privateKey: string, provider: Provider, networkOverrides: networkOverrides) => {
+    return new Wallet<typeof networkOverrides>(privateKey, provider, networkOverrides);
 }

--- a/src.ts/wallet/wallet.ts
+++ b/src.ts/wallet/wallet.ts
@@ -12,7 +12,7 @@ import {
 import { Mnemonic } from "./mnemonic.js";
 
 import type { ProgressCallback } from "../crypto/index.js";
-import type { Provider, TransactionRequest } from "../providers/index.js";
+import type { Provider } from "../providers/index.js";
 
 import type { CrowdsaleAccount } from "./json-crowdsale.js";
 import type { KeystoreAccount } from "./json-keystore.js";

--- a/src.ts/wallet/wallet.ts
+++ b/src.ts/wallet/wallet.ts
@@ -163,7 +163,6 @@ export class Wallet<TNetworkOverrides extends NetworkOverrides = {}> extends Bas
     }
 }
 
-// TODO networkOverrides should be optional
-export const createWallet = <networkOverrides extends NetworkOverrides>(privateKey: string, provider: Provider, networkOverrides: networkOverrides) => {
-    return new Wallet<typeof networkOverrides>(privateKey, provider, networkOverrides);
+export const createWallet = <networkOverrides extends NetworkOverrides>(privateKey: string, provider: Provider, networkOverrides?: networkOverrides) => {
+    return new Wallet<networkOverrides>(privateKey, provider, networkOverrides);
 }


### PR DESCRIPTION
Aim of this PR is to show how support for fee currencies could be achieved using more type-based and network overrides object approach.

Because of the types it allows to specify `feeCurrency` on the top level of transaction request with proper typing support:

<img width="560" alt="Screenshot 2024-02-29 at 12 13 42" src="https://github.com/celo-org/ethers.js/assets/312010/b2925057-178f-41e2-b688-76fa817b5e5e">

<img width="678" alt="Screenshot 2024-02-29 at 12 16 03" src="https://github.com/celo-org/ethers.js/assets/312010/74fbfa9a-a9f1-4bab-b4e5-d1d84ce37272">

<img width="526" alt="Screenshot 2024-02-29 at 12 17 39" src="https://github.com/celo-org/ethers.js/assets/312010/21f5c67a-e96e-442b-a0c6-6c64a733ed5d">

To test it I used the following script that existed in a directory adjacent to directory to which ethers has been cloned to. I ran it using [bun](https://bun.sh/).

It requires `dotenv` to work and `PRIVATE_KEY` specified in `.env` file although can be modified to work without it.

It works with alfajores network only for now.

It also requires the sender to have sufficient funds to a) transfer CELO b) pay for the fee currency. Both can be acquired using [the faucet](https://faucet.celo.org/alfajores).

```typescript
import "dotenv/config";
import { celoAlfajores } from "../ethers.js/src.ts/chain/celo.ts";
import { createWallet } from "../ethers.js/src.ts/wallet/wallet.ts";
import { createJsonRpcProvider } from "../ethers.js/src.ts/providers/provider-jsonrpc.ts";

const provider = createJsonRpcProvider("https://alfajores-forno.celo-testnet.org", undefined, undefined, celoAlfajores);
const signer = createWallet(process.env.PRIVATE_KEY as string, provider, celoAlfajores);

let tx;

console.log("Try to send a CELO CIP-64 transaction...");
tx = await signer.sendTransaction({
    to: signer.address,
    value: 1n,
    feeCurrency: "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1",
});

// should be true
console.log(tx.type === 123);

console.log("Try to send an EIP-1559 transaction...");
tx = await signer.sendTransaction({
    to: signer.address,
    value: 1n,
});

// should be true
console.log(tx.type === 2);
```

When everything works correctly the script should output:

```
$ bun send.ts

Try to send a CELO CIP-64 transaction...
true
Try to send an EIP-1559 transaction...
true
```